### PR TITLE
Removing mandatory href attribute from ProtocolRef. OCECDR-4511

### DIFF
--- a/App/Dtd/pdq.dtd
+++ b/App/Dtd/pdq.dtd
@@ -299,8 +299,7 @@
 <!ATTLIST KeyPoint id CDATA #IMPLIED>
 
 <!ELEMENT ProtocolRef (#PCDATA)>
-<!ATTLIST ProtocolRef href CDATA #REQUIRED
-                      nct_id CDATA #REQUIRED>
+<!ATTLIST ProtocolRef nct_id CDATA #REQUIRED>
 
 <!ELEMENT ProtocolLink (#PCDATA)>
 <!ATTLIST ProtocolLink ref CDATA #REQUIRED>


### PR DESCRIPTION
DTD change - CDR doesn't link to internal protocol documents anymore.