### PR TITLE
Glossary PP Report - WCMSFEQ-1394

### DIFF
--- a/App/CDRPreviewWS/CGovHtml.aspx
+++ b/App/CDRPreviewWS/CGovHtml.aspx
@@ -43,6 +43,13 @@
       </script>
       <link href="<%=serverUrl%>/PublishedContent/Styles/PDQPage.css" rel="stylesheet" />
       <link href="<%=serverUrl%>/PublishedContent/Styles/InnerPage.css" rel="stylesheet" />
+      <!-- 
+        Temporary overwrite to prevent PP report for glossaries with
+        images from floating text of the Spanish definition
+      -->
+      <style>
+         dl.dictionary-list figure.image-left-medium { float: none; }
+      </style>
     </head>
 
   <body class="pdqcancerinfosummary">

--- a/App/CDRPreviewWS/CGovHtml.aspx
+++ b/App/CDRPreviewWS/CGovHtml.aspx
@@ -43,7 +43,7 @@
       </script>
       <link href="<%=serverUrl%>/PublishedContent/Styles/PDQPage.css" rel="stylesheet" />
       <link href="<%=serverUrl%>/PublishedContent/Styles/InnerPage.css" rel="stylesheet" />
-      <!-- 
+      <!--
         Temporary overwrite to prevent PP report for glossaries with
         images from floating text of the Spanish definition
       -->


### PR DESCRIPTION
Adding temporary CSS overwrite to PublishPreview report (GK template) to disable floating text for glossary terms with images.